### PR TITLE
Change default value handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,7 @@ config :libcluster,
     example: [
       strategy: ClusterEC2.Strategy.Tags,
       config: [
-        ec2_tagname: "elasticbeanstalk:environment-name",
-        ec2_tagvalue: &ClusterEC2.local_instance_tag_value/1,
-        app_prefix: "phoenix"
+        ec2_tagname: "elasticbeanstalk:environment-name"
       ],
     ]
   ]


### PR DESCRIPTION
Thank you for your time in developing this ec2 strategy for libcluster.

If somebody wants to use distillery it's not possible to use `ClusterEC2.local_instance_tag_value` in the  config. Therefore I changed it to default and made the out of the box config simpler. 