### PR TITLE
Fix reconnection on failure and add tuple handling

### DIFF
--- a/lib/libcluster_ec2.ex
+++ b/lib/libcluster_ec2.ex
@@ -5,6 +5,7 @@ defmodule ClusterEC2 do
   @moduledoc File.read!("#{__DIR__}/../README.md")
 
   plug Tesla.Middleware.BaseUrl, "http://169.254.169.254/latest/meta-data"
+  plug Tesla.Middleware.Tuples
 
   @doc """
     Queries the local EC2 instance metadata API to determine the instance ID of the current instance.
@@ -12,7 +13,7 @@ defmodule ClusterEC2 do
   @spec local_instance_id() :: binary()
   def local_instance_id do
     case get("/instance-id/") do
-      %{status: 200, body: body} -> body
+      {:ok, %{status: 200, body: body}} -> body
       _ -> ""
     end
   end
@@ -23,7 +24,7 @@ defmodule ClusterEC2 do
   @spec instance_region() :: binary()
   def instance_region do
     case get("/placement/availability-zone/") do
-      %{status: 200, body: body} -> String.slice(body, 0..-2)
+      {:ok, %{status: 200, body: body}} -> String.slice(body, 0..-2)
       _ -> ""
     end
   end

--- a/lib/strategy/tags.ex
+++ b/lib/strategy/tags.ex
@@ -83,6 +83,7 @@ defmodule ClusterEC2.Strategy.Tags do
         Process.send_after(self(), :load, Keyword.get(state.config, :polling_interval, @default_polling_interval))
         {:noreply, %{state | :meta => new_nodelist}}
       _ ->
+        Process.send_after(self(), :load, Keyword.get(state.config, :polling_interval, @default_polling_interval))
         {:noreply, state}
     end
   end

--- a/test/libcluster_ec2_test.exs
+++ b/test/libcluster_ec2_test.exs
@@ -12,11 +12,11 @@ defmodule ClusterEC2Test do
     :ok
   end
 
-  test "test return local_instance_id" do
+  test "return local_instance_id" do
     assert "i-0fdde7ca9faef9751" == ClusterEC2.local_instance_id()
   end
 
-  test "test return instance_region" do
+  test "return instance_region" do
     assert "eu-central-1" == ClusterEC2.instance_region()
   end
 end


### PR DESCRIPTION
Sorry, unfortunately I missed some points in the latest pr.

- fix missing `Process.send_after`
- Add tuple response to prevent exceptions