### PR TITLE
fix public address detection

### DIFF
--- a/lib/strategy/tags.ex
+++ b/lib/strategy/tags.ex
@@ -190,7 +190,7 @@ defmodule ClusterEC2.Strategy.Tags do
     do: ~x"//DescribeInstancesResponse/reservationSet/item/instancesSet/item/privateIpAddress/text()"ls
 
   defp ip_xpath(:public),
-    do: ~x"//DescribeInstancesResponse/reservationSet/item/instancesSet/item/publicIpAddress/text()"ls
+    do: ~x"//DescribeInstancesResponse/reservationSet/item/instancesSet/item/IpAddress/text()"ls
 
   defp fetch_tag_value(_k, v) when is_function(v, 0), do: v.()
   defp fetch_tag_value(k, v) when is_function(v, 1), do: v.(k)


### PR DESCRIPTION
https://docs.aws.amazon.com/AWSEC2/latest/APIReference/API_Instance.html
there is no publicIpAddress. IpAddress is used instead.