### PR TITLE
Enhancement: give user ability to configure whether or not to show the debug log

### DIFF
--- a/lib/strategy/tags.ex
+++ b/lib/strategy/tags.ex
@@ -16,7 +16,8 @@ defmodule ClusterEC2.Strategy.Tags do
               app_prefix: "app",
               ip_to_nodename: &my_nodename_func/2,
               ip_type: :private,
-              polling_interval: 10_000]]]
+              polling_interval: 10_000]]],
+              show_debug: false
 
   ## Configuration Options
 
@@ -28,6 +29,7 @@ defmodule ClusterEC2.Strategy.Tags do
   | `:ip_type` | no | One of :private or :public, defaults to :private |
   | `:ip_to_nodename` | no | defaults to `app_prefix@ip` but can be used to override the nodename |
   | `:polling_interval` | no | Number of milliseconds to wait between polls to the EC2 api. Defaults to 5_000 |
+  | `:show_debug` | no | True or false, whether or not to show the debug log. Defaults to true |
   """
 
   use GenServer
@@ -126,13 +128,14 @@ defmodule ClusterEC2.Strategy.Tags do
     tag_value = Keyword.get(config, :ec2_tagvalue, &local_instance_tag_value(&1, instance_id, region))
     app_prefix = Keyword.get(config, :app_prefix, "app")
     ip_to_nodename = Keyword.get(config, :ip_to_nodename, &ip_to_nodename/2)
+    show_debug? = Keyword.get(config, :show_debug, true)
 
     cond do
       tag_name != nil and tag_value != nil and app_prefix != nil and instance_id != "" and region != "" ->
         params = [filters: ["tag:#{tag_name}": fetch_tag_value(tag_name, tag_value), "instance-state-name": "running"]]
         request = ExAws.EC2.describe_instances(params)
         require Logger
-        Logger.debug("#{inspect(request)}")
+        if show_debug?, do: Logger.debug("#{inspect(request)}")
 
         case ExAws.request(request, region: region) do
           {:ok, %{body: body}} ->


### PR DESCRIPTION
I see the debug log spamming my servers hard and wanted to add the ability so that users can configure this in the config by passing `show_debug: false` or `show_debug: true`. Defaults to true if this option is not passed.

Thanks!