### PR TITLE
Add support for IMDS v2

### DIFF
--- a/lib/libcluster_ec2.ex
+++ b/lib/libcluster_ec2.ex
@@ -3,26 +3,52 @@ defmodule ClusterEC2 do
 
   @moduledoc File.read!("#{__DIR__}/../README.md")
 
-  plug(Tesla.Middleware.BaseUrl, "http://169.254.169.254/latest/meta-data")
+  plug(Tesla.Middleware.BaseUrl, "http://169.254.169.254/latest")
 
   @doc """
     Queries the local EC2 instance metadata API to determine the instance ID of the current instance.
   """
-  @spec local_instance_id() :: binary()
-  def local_instance_id do
-    case get("/instance-id/") do
-      {:ok, %{status: 200, body: body}} -> body
-      _ -> ""
+  @spec local_instance_id(use_imds_v2 :: boolean()) :: binary()
+  def local_instance_id(true) do
+    with token when token != "" <- get_token(),
+         body <- get_body("/meta-data/instance-id/", [{"X-aws-ec2-metadata-token", token}]) do
+      body
+    end
+  end
+
+  def local_instance_id(false) do
+    with body <- get_body("/meta-data/instance-id/") do
+      body
     end
   end
 
   @doc """
     Queries the local EC2 instance metadata API to determine the aws resource region of the current instance.
   """
-  @spec instance_region() :: binary()
-  def instance_region do
-    case get("/placement/availability-zone/") do
-      {:ok, %{status: 200, body: body}} -> String.slice(body, 0..-2)
+  @spec instance_region(use_imds_2 :: boolean()) :: binary()
+  def instance_region(true) do
+    with token when token != "" <- get_token(),
+         body <- get_body("/meta-data/placement/availability-zone/", [{"X-aws-ec2-metadata-token", token}]) do
+      String.slice(body, 0..-2)
+    end
+  end
+
+  def instance_region(false) do
+    with body <- get_body("/meta-data/placement/availability-zone/") do
+      String.slice(body, 0..-2)
+    end
+  end
+
+  defp get_body(url, headers \\ []) do
+    case get(url, headers: headers) do
+      {:ok, %{status: 200, body: body}} -> body
+      _ -> ""
+    end
+  end
+
+  defp get_token do
+    case put("/api/token", nil, headers: [{"X-aws-ec2-metadata-token-ttl-seconds", "21600"}]) do
+      {:ok, %{status: 200, body: body}} -> body
       _ -> ""
     end
   end

--- a/lib/strategy/tags.ex
+++ b/lib/strategy/tags.ex
@@ -25,6 +25,7 @@ defmodule ClusterEC2.Strategy.Tags do
   | --- | -------- | ----------- |
   | `:ec2_tagname` | yes | Name of the EC2 instance tag to look for. |
   | `:ec2_tagvalue` | no | Can be passed a static value (string), a 0-arity function, or a 1-arity function (which will be passed the value of `:ec2_tagname` at invocation). |
+  | `:use_imds_v2` | no | Use IMDSv2. Defaults to true |
   | `:app_prefix` | no | Will be prepended to the node's private IP address to create the node name. |
   | `:ip_type` | no | One of :private or :public, defaults to :private |
   | `:ip_to_nodename` | no | defaults to `app_prefix@ip` but can be used to override the nodename |
@@ -122,8 +123,9 @@ defmodule ClusterEC2.Strategy.Tags do
 
   @spec get_nodes(State.t()) :: {:ok, [atom()]} | {:error, []}
   defp get_nodes(%State{topology: topology, config: config}) do
-    instance_id = ClusterEC2.local_instance_id()
-    region = ClusterEC2.instance_region()
+    use_imds_v2 = Keyword.get(config, :use_imds_v2, true)
+    instance_id = ClusterEC2.local_instance_id(use_imds_v2)
+    region = ClusterEC2.instance_region(use_imds_v2)
     tag_name = Keyword.fetch!(config, :ec2_tagname)
     tag_value = Keyword.get(config, :ec2_tagvalue, &local_instance_tag_value(&1, instance_id, region))
     app_prefix = Keyword.get(config, :app_prefix, "app")

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule ClusterEC2.Mixfile do
   def project do
     [
       app: :libcluster_ec2,
-      version: "0.7.0",
+      version: "0.8.0",
       elixir: "~> 1.4",
       name: "libcluster_ec2",
       source_url: "https://github.com/kyleaa/libcluster_ec2",

--- a/test/libcluster_ec2_test.exs
+++ b/test/libcluster_ec2_test.exs
@@ -4,21 +4,45 @@ defmodule ClusterEC2Test do
 
   setup do
     Tesla.Mock.mock(fn
+      %{
+        method: :get,
+        url: "http://169.254.169.254/latest/meta-data/instance-id/",
+        headers: [{"X-aws-ec2-metadata-token", "test-token-foo"}]
+      } ->
+        %Tesla.Env{status: 200, body: "i-0fdde7ca9faef9792"}
+
       %{method: :get, url: "http://169.254.169.254/latest/meta-data/instance-id/"} ->
         %Tesla.Env{status: 200, body: "i-0fdde7ca9faef9751"}
 
+      %{
+        method: :get,
+        url: "http://169.254.169.254/latest/meta-data/placement/availability-zone/",
+        headers: [{"X-aws-ec2-metadata-token", "test-token-foo"}]
+      } ->
+        %Tesla.Env{status: 200, body: "eu-west-1b"}
+
       %{method: :get, url: "http://169.254.169.254/latest/meta-data/placement/availability-zone/"} ->
         %Tesla.Env{status: 200, body: "eu-central-1b"}
+
+      %{
+        method: :put,
+        url: "http://169.254.169.254/latest/api/token",
+        body: nil,
+        headers: [{"X-aws-ec2-metadata-token-ttl-seconds", "21600"}]
+      } ->
+        %Tesla.Env{status: 200, body: "test-token-foo"}
     end)
 
     :ok
   end
 
   test "return local_instance_id" do
-    assert "i-0fdde7ca9faef9751" == ClusterEC2.local_instance_id()
+    assert "i-0fdde7ca9faef9751" == ClusterEC2.local_instance_id(false)
+    assert "i-0fdde7ca9faef9792" == ClusterEC2.local_instance_id(true)
   end
 
   test "return instance_region" do
-    assert "eu-central-1" == ClusterEC2.instance_region()
+    assert "eu-central-1" == ClusterEC2.instance_region(false)
+    assert "eu-west-1" == ClusterEC2.instance_region(true)
   end
 end

--- a/test/strategy/tags_error_test.exs
+++ b/test/strategy/tags_error_test.exs
@@ -17,7 +17,8 @@ defmodule Strategy.TagsErrorTest do
       disconnect: {:net_kernel, :disconnect, []},
       list_nodes: {:erlang, :nodes, [:connected]},
       config: [
-        ec2_tagname: "elasticbeanstalk:environment-name"
+        ec2_tagname: "elasticbeanstalk:environment-name",
+        use_imds_v2: false
       ]
     ]
 
@@ -29,7 +30,7 @@ defmodule Strategy.TagsErrorTest do
     assert :load == send(pid, :load)
 
     assert %Cluster.Strategy.State{
-             config: [ec2_tagname: "elasticbeanstalk:environment-name"],
+             config: [ec2_tagname: "elasticbeanstalk:environment-name", use_imds_v2: false],
              connect: {:net_kernel, :connect, []},
              disconnect: {:net_kernel, :disconnect, []},
              list_nodes: {:erlang, :nodes, [:connected]},

--- a/test/strategy/tags_test.exs
+++ b/test/strategy/tags_test.exs
@@ -17,7 +17,8 @@ defmodule Strategy.TagsTest do
       disconnect: {:net_kernel, :disconnect, []},
       list_nodes: {:erlang, :nodes, [:connected]},
       config: [
-        ec2_tagname: "elasticbeanstalk:environment-name"
+        ec2_tagname: "elasticbeanstalk:environment-name",
+        use_imds_v2: false
       ]
     ]
 
@@ -29,7 +30,7 @@ defmodule Strategy.TagsTest do
     assert :load == send(pid, :load)
 
     assert %Cluster.Strategy.State{
-             config: [ec2_tagname: "elasticbeanstalk:environment-name"],
+             config: [ec2_tagname: "elasticbeanstalk:environment-name", use_imds_v2: false],
              connect: {:net_kernel, :connect, []},
              disconnect: {:net_kernel, :disconnect, []},
              list_nodes: {:erlang, :nodes, [:connected]},


### PR DESCRIPTION
Hello!

I've hit a problem - `libcluster` was unable to describe local instance within my Elastic Beanstalk setup, as `169.254.169.254` is protected and not accessible within [IMDSv2](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html) (which is enabled by default).

This PR reproduces the suggested steps described in official documentation, and amends current _default_ behaviour to always obtain token. The instances that are subject to IMDSv1 will still respond with such token, it's just it is not required to query the Metadata Service, however, it can be disabled through configuration, eg:

```elixir
    topologies = [
      topology_for_fun: [
        strategy: ClusterEC2.Strategy.Tags,
        config: [
          ec2_tagname: "Name",
          ec2_tagvalue: "Forfun-env",
          app_prefix: "me",
          use_imds_v2: false
        ]
      ]
    ]
```

Finally - thank you for your amazing job @kyleaa! This wouldn't be possible without your library in first place! :)
