### PR TITLE
relax ex_aws requirement

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -28,7 +28,7 @@ defmodule ClusterEC2.Mixfile do
   defp deps do
     [
       {:libcluster, "~> 2.0 or ~> 3.0"},
-      {:ex_aws, "~> 2.3.2"},
+      {:ex_aws, ">= 2.3.2"},
       {:ex_aws_ec2, "~> 2.0"},
       {:sweet_xml, "~> 0.6"},
       {:hackney, "~> 1.8"},


### PR DESCRIPTION
This should allow for versions x.y where x >= 2 && y >= 3

As part of this change, could you also release a new version say 0.8.1 on hex.pm since people that aren't using ex_aws 2.3.x won't be able to install this package.